### PR TITLE
Fix/dash sort

### DIFF
--- a/PUGPlanner-Backend/Repositories/GameRepository.cs
+++ b/PUGPlanner-Backend/Repositories/GameRepository.cs
@@ -33,7 +33,7 @@ namespace PUGPlanner_Backend.Repositories
                             LEFT JOIN UserProfile up ON g.UserProfileId = up.Id
                             JOIN [Position] p ON up.PrimaryPositionId = p.id
                             JOIN [Position] p2 ON up.SecondaryPositionId = p2.id
-                        ORDER BY g.GameDate DESC";
+                        ORDER BY g.GameDate ASC";
 
                     List<Game> games = new();
 

--- a/PUGPlanner-Backend/Repositories/GameRepository.cs
+++ b/PUGPlanner-Backend/Repositories/GameRepository.cs
@@ -32,7 +32,8 @@ namespace PUGPlanner_Backend.Repositories
                         FROM Game g
                             LEFT JOIN UserProfile up ON g.UserProfileId = up.Id
                             JOIN [Position] p ON up.PrimaryPositionId = p.id
-                            JOIN [Position] p2 ON up.SecondaryPositionId = p2.id";
+                            JOIN [Position] p2 ON up.SecondaryPositionId = p2.id
+                        ORDER BY g.GameDate DESC";
 
                     List<Game> games = new();
 

--- a/pugplanner-frontend/src/dashboard/Dashboard.js
+++ b/pugplanner-frontend/src/dashboard/Dashboard.js
@@ -12,6 +12,10 @@ export const Dashboard = ({ isAdmin }) => {
 
     const navToGameForm = () => navigate("/new-game")
 
+    /**
+     * Filter out games that have had their game date past the current date
+     * @param {array} gamesArr 
+     */
     const filterGames = (gamesArr) => {
         const currentGames = gamesArr.filter(game => game.gameDateStatus > -1);
         setGames(currentGames);

--- a/pugplanner-frontend/src/dashboard/Dashboard.js
+++ b/pugplanner-frontend/src/dashboard/Dashboard.js
@@ -12,8 +12,13 @@ export const Dashboard = ({ isAdmin }) => {
 
     const navToGameForm = () => navigate("/new-game")
 
+    const filterGames = (gamesArr) => {
+        const currentGames = gamesArr.filter(game => game.gameDateStatus > -1);
+        setGames(currentGames);
+    };
+
     useEffect(() => {
-        fetchGames().then(games => setGames(games));
+        fetchGames().then(games => filterGames(games));
     }, []);
 
     return (

--- a/pugplanner-frontend/src/dashboard/Dashboard.js
+++ b/pugplanner-frontend/src/dashboard/Dashboard.js
@@ -1,4 +1,4 @@
-import { PlusCircleIcon } from "@heroicons/react/24/outline";
+import { FunnelIcon, PlusCircleIcon } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { GameCard } from "../game/GameCard";
@@ -6,37 +6,62 @@ import { fetchGames } from "../managers/GameManager";
 
 export const Dashboard = ({ isAdmin }) => {
 
+    const [allGames, setAllGames] = useState([]);
     const [games, setGames] = useState([]);
+    const [isPast, setIsPast] = useState(false);
 
     const navigate = useNavigate();
 
     const navToGameForm = () => navigate("/new-game")
 
     /**
-     * Filter out games that have had their game date past the current date
-     * @param {array} gamesArr 
+     * Filter games based on if their game date has past or not
      */
-    const filterGames = (gamesArr) => {
-        const currentGames = gamesArr.filter(game => game.gameDateStatus > -1);
-        setGames(currentGames);
+    const filterGames = () => {
+
+        let filteredGames = [];
+
+        if (!isPast) {
+            filteredGames = allGames.filter(game => game.gameDateStatus > -1);
+            setGames(filteredGames);
+        }
+        else {
+            filteredGames = allGames.filter(game => game.gameDateStatus < 0);
+            setGames(filteredGames);
+        }
     };
 
+    const toggleDateFilter = () => setIsPast(!isPast);
+
     useEffect(() => {
-        fetchGames().then(games => filterGames(games));
+        filterGames(games);
+    }, [isPast, allGames]);
+
+    useEffect(() => {
+        fetchGames().then(games => setAllGames(games));
     }, []);
 
     return (
         <div className="px-2 last:pb-6">
             <div className="px-5 py-5 mx-auto max-w-lg">
-                {isAdmin &&
+                <div className="flex">
                     <button
                         className="flex rounded-md border border-transparent bg-lime-200 py-2 pr-4 pl-3 mr-3 text-sm font-medium text-black shadow-sm hover:bg-lime-300 focus:bg-lime-300"
-                        onClick={navToGameForm}
+                        onClick={toggleDateFilter}
                     >
-                        <PlusCircleIcon className="h-5 w-5 mr-1 flex-shrink text-slate-600" aria-hidden="true" />
-                        New Game
+                        <FunnelIcon className="h-5 w-5 mr-1 flex-shrink text-slate-600" aria-hidden="true" />
+                        {isPast ? "Show Current" : "Show Past"}
                     </button>
-                }
+                    {isAdmin &&
+                        <button
+                            className="flex rounded-md border border-transparent bg-lime-200 py-2 pr-4 pl-3 mr-3 text-sm font-medium text-black shadow-sm hover:bg-lime-300 focus:bg-lime-300"
+                            onClick={navToGameForm}
+                        >
+                            <PlusCircleIcon className="h-5 w-5 mr-1 flex-shrink text-slate-600" aria-hidden="true" />
+                            New Game
+                        </button>
+                    }
+                </div>
                 {games.map(game => <GameCard key={game.id} game={game} />)}
             </div>
         </div>

--- a/pugplanner-frontend/src/game/GameCard.js
+++ b/pugplanner-frontend/src/game/GameCard.js
@@ -59,7 +59,7 @@ export const GameCard = ({ game }) => {
                             <dt className="text-sm font-medium text-gray-500">Roster</dt>
                             <dd className="mt-1 text-sm text-gray-900 sm:col-span-2 sm:mt-0"> {
                                 isWaitList ?
-                                    `${game.maxPlayers} / ${game.maxPlayers} + (${rosterCount.currentPlayers} on waitlist)`
+                                    `${game.maxPlayers} / ${game.maxPlayers} + (${rosterCount.currentPlayers - game.maxPlayers} on waitlist)`
                                     :
                                     `${rosterCount.currentPlayers} / ${game.maxPlayers}`
                             }

--- a/pugplanner-frontend/src/nav/AppNav.js
+++ b/pugplanner-frontend/src/nav/AppNav.js
@@ -25,7 +25,7 @@ export const AppNav = () => {
     if (user.admin) {
         navigation = [
             { name: 'Dashboard', onClick: navToDashboard, current: false },
-            { name: 'Player Admin', onClick: navToPlayerAdmin, current: false }
+            // { name: 'Player Admin', onClick: navToPlayerAdmin, current: false }
         ];
     }
     else {


### PR DESCRIPTION
This PR resolves #27 

The dashboard games are now sorted by game date ascending and don't display games who's game date has passed.

The dashboard also not includes a filter toggle to show past games / current games.