### PR TITLE
Add conditional to check if final waitlist member

### DIFF
--- a/pugplanner-frontend/src/game/GameDetails.js
+++ b/pugplanner-frontend/src/game/GameDetails.js
@@ -51,6 +51,10 @@ export const GameDetails = ({ isAdmin }) => {
       setRegLockModalOpen(true);
    };
 
+   /**
+    * Handles un-registering current user from roster by deleting them from roster
+    * Additionally checks if there's only one wait-list player remaining and removes wait-list if so
+    */
    const handleUnregister = () => {
       if (waitList.length === 1) {
          setIsWaitList(false);
@@ -103,7 +107,9 @@ export const GameDetails = ({ isAdmin }) => {
    };
 
    /**
-    * Checks if current user is already registered and if registration date status is open (-1)
+    * Checks if current user is already registered
+    * Checks if game date status is not yet passed (1) and registration date status is open / past (-1)
+    * Sets user registration ability state
     */
    const checkCanRegister = (rosterArr, gameObj) => {
       const userId = getCurrentUser().id;

--- a/pugplanner-frontend/src/game/GameDetails.js
+++ b/pugplanner-frontend/src/game/GameDetails.js
@@ -52,6 +52,9 @@ export const GameDetails = ({ isAdmin }) => {
    };
 
    const handleUnregister = () => {
+      if (waitList.length === 1) {
+         setIsWaitList(false);
+      }
       deleteUserFromRoster(game.id);
       setCanUnregister(false);
       setUnregisterModalOpen(false);


### PR DESCRIPTION
This PR resolves issue #20 .

A conditional was added to the un-registration handler function to check if there was only 1 member in waitlist. If so, change state to remove wait-list when player is removed from roster. 

Seemingly bug free.