### PR TITLE
Enhance/tele format

### DIFF
--- a/PUGPlanner-Backend/Models/User.cs
+++ b/PUGPlanner-Backend/Models/User.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using Microsoft.IdentityModel.Tokens;
+using System.ComponentModel.DataAnnotations;
 
 namespace PUGPlanner_Backend.Models
 {
@@ -66,11 +67,28 @@ namespace PUGPlanner_Backend.Models
         {
             get
             {
-                return $"{FirstName} at {Phone}";
+                return $"{FirstName} at {PhoneString}";
             }
         }
 
         public string JoinYear => CreateDateTime.ToString("yyyy");
+
+        private string FormatPhone (string phone)
+        {
+            var areaCodeValues = phone.Take(3);
+            var middleThreeValues = phone.Skip(3).Take(3);
+            var lastFourValues = phone.Skip(5).Take(4);
+
+            string areaCode = string.Join("", areaCodeValues);
+            string middleThree = string.Join("", middleThreeValues);
+            string lastFour = string.Join("", lastFourValues);
+
+
+            return $"({areaCode}) {middleThree}-{lastFour}";
+        }
+
+        public string PhoneString => FormatPhone(Phone);
+        public string EmergencyPhoneString => FormatPhone(EmergencyPhone);
 
     }
 }

--- a/pugplanner-frontend/src/profile/PlayerProfile.js
+++ b/pugplanner-frontend/src/profile/PlayerProfile.js
@@ -97,10 +97,10 @@ export const PlayerProfile = ({ isAdmin }) => {
                      <div className="mt-1">{player.club}</div>
                      {isAdmin && (
                         <>
-                           <div className="mt-1">{player.phone}</div>
+                           <div className="mt-1">{player.phoneString}</div>
                            <div className="mt-1">{player.email}</div>
                            <div className="mt-1">
-                              Emergency contact: {player.emergencyName} at {player.emergencyPhone}
+                              Emergency contact: {player.emergencyName} at {player.emergencyPhoneString}
                            </div>
                         </>
                      )}


### PR DESCRIPTION
This PR closes issue #45 . Telephone numbers have been formatted in the C# model `User.cs` .

A method has been written to convert the phone properties using Take, Skip and Join methods. An attempt was made to use `String.Format()`, but was not working with the following code:

`String.Format("{0:(###) ###-####}", Phone);`

The enhancement is working just fine with Take, Skip and Join.