### PR TITLE
Fix/user null values

### DIFF
--- a/PUGPlanner-Backend/Models/Pronoun.cs
+++ b/PUGPlanner-Backend/Models/Pronoun.cs
@@ -2,7 +2,7 @@
 {
     public class Pronoun
     {
-        public int Id { get; set; }
+        public int? Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/PUGPlanner-Backend/Repositories/UserRepository.cs
+++ b/PUGPlanner-Backend/Repositories/UserRepository.cs
@@ -30,7 +30,7 @@ namespace PUGPlanner_Backend.Repositories
                                p.FullName as PrimaryPositionFullName, p2.FullName as SecondaryPositionFullName,
                                pn.[Name] as PronounName
                           FROM [UserProfile] up
-                              JOIN Pronoun pn ON up.PronounId = pn.Id
+                              LEFT JOIN Pronoun pn ON up.PronounId = pn.Id
                               JOIN [Position] p ON up.PrimaryPositionId = p.id
                               JOIN [Position] p2 ON up.SecondaryPositionId = p2.id
                          WHERE up.Id = @id";
@@ -68,7 +68,7 @@ namespace PUGPlanner_Backend.Repositories
                                p.FullName as PrimaryPositionFullName, p2.FullName as SecondaryPositionFullName,
                                pn.[Name] as PronounName
                           FROM [UserProfile] up
-                              JOIN Pronoun pn ON up.PronounId = pn.Id
+                              LEFT JOIN Pronoun pn ON up.PronounId = pn.Id
                               JOIN [Position] p ON up.PrimaryPositionId = p.id
                               JOIN [Position] p2 ON up.SecondaryPositionId = p2.id
                           ORDER BY up.LastName";
@@ -185,7 +185,7 @@ namespace PUGPlanner_Backend.Repositories
         /// <returns>User object</returns>
         private User NewUserFromReader(SqlDataReader reader)
         {
-            return new User()
+            User user = new()
             {
                 Id = DbUtils.GetInt(reader, "UserId"),
                 FirstName = DbUtils.GetString(reader, "FirstName"),
@@ -207,13 +207,18 @@ namespace PUGPlanner_Backend.Repositories
                     Secondary = DbUtils.GetNullableString(reader, "SecondaryPositionName"),
                     PrimaryFull = DbUtils.GetNullableString(reader, "PrimaryPositionFullName"),
                     SecondaryFull = DbUtils.GetNullableString(reader, "SecondaryPositionFullName"),
-                },
-                Pronoun = new Pronoun()
+                }
+            };
+
+            if (DbUtils.IsNotDbNull(reader, "PronounId"))
+            {
+                user.Pronoun = new Pronoun
                 {
                     Id = DbUtils.GetNullableInt(reader, "PronounId"),
                     Name = DbUtils.GetNullableString(reader, "PronounName"),
-                }
-            };
+                };
+            }
+            return user;
         }
 
         public void Add(User user)

--- a/PUGPlanner-Backend/Repositories/UserRepository.cs
+++ b/PUGPlanner-Backend/Repositories/UserRepository.cs
@@ -192,10 +192,10 @@ namespace PUGPlanner_Backend.Repositories
                 LastName = DbUtils.GetString(reader, "LastName"),
                 Email = DbUtils.GetString(reader, "Email"),
                 Phone = DbUtils.GetString(reader, "Phone"),
-                Club = DbUtils.GetString(reader, "Club"),
+                Club = DbUtils.GetNullableString(reader, "Club"),
                 PrimaryPositionId = DbUtils.GetInt(reader, "PrimaryPositionId"),
                 SecondaryPositionId = DbUtils.GetInt(reader, "SecondaryPositionId"),
-                PronounId = DbUtils.GetInt(reader, "PronounId"),
+                PronounId = DbUtils.GetNullableInt(reader, "PronounId"),
                 CreateDateTime = DbUtils.GetDateTime(reader, "CreateDateTime"),
                 Admin = DbUtils.GetBool(reader, "Admin"),
                 EmergencyName = DbUtils.GetString(reader, "EmergencyName"),
@@ -203,15 +203,15 @@ namespace PUGPlanner_Backend.Repositories
                 Active = DbUtils.GetBool(reader, "Active"),
                 Position = new UserPosition()
                 {
-                    Primary = DbUtils.GetString(reader, "PrimaryPositionName"),
-                    Secondary = DbUtils.GetString(reader, "SecondaryPositionName"),
-                    PrimaryFull = DbUtils.GetString(reader, "PrimaryPositionFullName"),
-                    SecondaryFull = DbUtils.GetString(reader, "SecondaryPositionFullName"),
+                    Primary = DbUtils.GetNullableString(reader, "PrimaryPositionName"),
+                    Secondary = DbUtils.GetNullableString(reader, "SecondaryPositionName"),
+                    PrimaryFull = DbUtils.GetNullableString(reader, "PrimaryPositionFullName"),
+                    SecondaryFull = DbUtils.GetNullableString(reader, "SecondaryPositionFullName"),
                 },
                 Pronoun = new Pronoun()
                 {
-                    Id = DbUtils.GetInt(reader, "PronounId"),
-                    Name = DbUtils.GetString(reader, "PronounName"),
+                    Id = DbUtils.GetNullableInt(reader, "PronounId"),
+                    Name = DbUtils.GetNullableString(reader, "PronounName"),
                 }
             };
         }

--- a/PUGPlanner-Backend/Utils/DbUtils.cs
+++ b/PUGPlanner-Backend/Utils/DbUtils.cs
@@ -78,6 +78,23 @@ namespace PUGPlanner_Backend.Utils
         }
 
         /// <summary>
+        ///  Get an string? (nullable string) from a data reader object and gracefully handle NULL values
+        /// </summary>
+        /// <param name="reader">A SqlDataReader that has not exhausted it's result set.</param>
+        /// <param name="column">The name of the column from the result set refereed to by the reader.</param>
+        /// <returns>The value of the given column or null.</returns>
+        public static string GetNullableString(SqlDataReader reader, string column)
+        {
+            var ordinal = reader.GetOrdinal(column);
+            if (reader.IsDBNull(ordinal))
+            {
+                return null;
+            }
+
+            return reader.GetString(ordinal);
+        }
+
+        /// <summary>
         ///  Get a DateTime? (nullable DateTime) from a data reader object and gracefully handle NULL values
         /// </summary>
         /// <param name="reader">A SqlDataReader that has not exhausted it's result set.</param>

--- a/pugplanner-frontend/src/profile/PlayerProfile.js
+++ b/pugplanner-frontend/src/profile/PlayerProfile.js
@@ -94,7 +94,7 @@ export const PlayerProfile = ({ isAdmin }) => {
                      {player.fullName}
                   </h3>
                   <div className="text-sm mt-0 mb-2 text-slate-400">
-                     ({player.pronoun?.name})
+                     {player.pronoun?.name}
                      <div className="mt-1">{player.club}</div>
                      {isAdmin && (
                         <>


### PR DESCRIPTION
This PR resolves #54 . A user who now registers without selecting club and / or pronoun will have no issues. 

This was done by adding nullable handling to both fields in the backend. A utils method was written for nullable strings.