### PR TITLE
Fix/game card fetch

### DIFF
--- a/PUGPlanner-Backend/Models/Game.cs
+++ b/PUGPlanner-Backend/Models/Game.cs
@@ -53,6 +53,6 @@ namespace PUGPlanner_Backend.Models
 
         public User PrimaryHost { get; set; }
         public User SecondaryHost { get; set; }
-
+        public int CurrentPlayers { get; set; }
     }
 }

--- a/PUGPlanner-Backend/Repositories/GameRepository.cs
+++ b/PUGPlanner-Backend/Repositories/GameRepository.cs
@@ -104,7 +104,8 @@ namespace PUGPlanner_Backend.Repositories
                                up2.EmergencyName as EmergencyName2, up2.EmergencyPhone as EmergencyPhone2, up2.Active as Active2,
                                p3.[Name] as PrimaryPositionName2, p4.[Name] as SecondaryPositionName2,
                                p3.FullName as PrimaryPositionFullName2, p4.FullName as SecondaryPositionFullName2,
-                               pn2.[Name] as PronounName2
+                               pn2.[Name] as PronounName2,
+                               PlayerCount
                         FROM Game g
                                LEFT JOIN UserProfile up ON g.PrimaryHostId = up.Id
                                LEFT JOIN UserProfile up2 ON g.SecondaryHostId = up2.Id
@@ -114,6 +115,11 @@ namespace PUGPlanner_Backend.Repositories
                                LEFT JOIN [Position] p3 ON up2.PrimaryPositionId = p3.Id
                                LEFT JOIN [Position] p4 ON up2.SecondaryPositionId = p4.Id
                                LEFT JOIN Pronoun pn2 ON up2.PronounId = pn2.Id
+                               LEFT JOIN (
+                                    SELECT cg.Id, Count(cg.Id) as PlayerCount
+                                    FROM Game cg
+                                    LEFT JOIN GameRoster gr ON cg.Id = gr.GameId
+                                    GROUP BY cg.Id) c ON g.Id = c.Id
                         WHERE g.id = @Id";
 
                     cmd.Parameters.AddWithValue("@Id", id);

--- a/PUGPlanner-Backend/Repositories/GameRepository.cs
+++ b/PUGPlanner-Backend/Repositories/GameRepository.cs
@@ -51,7 +51,7 @@ namespace PUGPlanner_Backend.Repositories
                                LEFT JOIN [Position] p4 ON up2.SecondaryPositionId = p4.Id
                                LEFT JOIN Pronoun pn2 ON up2.PronounId = pn2.Id
                                LEFT JOIN (
-                                    SELECT cg.Id, Count(cg.Id) as PlayerCount
+                                    SELECT cg.Id, Count(gr.GameId) as PlayerCount
                                     FROM Game cg
                                     LEFT JOIN GameRoster gr ON cg.Id = gr.GameId
                                     GROUP BY cg.Id ) c ON g.Id = c.Id
@@ -116,7 +116,7 @@ namespace PUGPlanner_Backend.Repositories
                                LEFT JOIN [Position] p4 ON up2.SecondaryPositionId = p4.Id
                                LEFT JOIN Pronoun pn2 ON up2.PronounId = pn2.Id
                                LEFT JOIN (
-                                    SELECT cg.Id, Count(cg.Id) as PlayerCount
+                                    SELECT cg.Id, Count(gr.GameId) as PlayerCount
                                     FROM Game cg
                                     LEFT JOIN GameRoster gr ON cg.Id = gr.GameId
                                     GROUP BY cg.Id) c ON g.Id = c.Id

--- a/pugplanner-frontend/src/game/GameCard.js
+++ b/pugplanner-frontend/src/game/GameCard.js
@@ -1,12 +1,10 @@
 import { CheckIcon, LockClosedIcon, LockOpenIcon } from '@heroicons/react/24/outline';
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { fetchGameRosterCount } from '../managers/RosterManager';
 
 export const GameCard = ({ game }) => {
    const navigate = useNavigate();
 
-   const [rosterCount, setRosterCount] = useState({});
    const [isWaitList, setIsWaitList] = useState(false);
 
    const handleDetails = () => {
@@ -17,18 +15,14 @@ export const GameCard = ({ game }) => {
     * Checks if current roster count is over game's max-players.
     */
    const checkIsWaitList = () => {
-      if (rosterCount.currentPlayers > game.maxPlayers) {
+      if (game.currentPlayers > game.maxPlayers) {
          setIsWaitList(true);
       }
    };
 
    useEffect(() => {
-      fetchGameRosterCount(game.id).then((countObj) => setRosterCount(countObj));
-   }, [game.id]);
-
-   useEffect(() => {
       checkIsWaitList();
-   }, [rosterCount]);
+   }, []);
 
    return (
       <>
@@ -97,9 +91,9 @@ export const GameCard = ({ game }) => {
                         {game.signupDateStatus < 0
                            ? isWaitList
                               ? `${game.maxPlayers} / ${game.maxPlayers} with ${
-                                   rosterCount.currentPlayers - game.maxPlayers
+                                   game.currentPlayers - game.maxPlayers
                                 } on wait-list`
-                              : `${rosterCount.currentPlayers} / ${game.maxPlayers}`
+                              : `${game.currentPlayers} / ${game.maxPlayers}`
                            : game.maxPlayers}
                      </dd>
                   </div>

--- a/pugplanner-frontend/src/game/GameCard.js
+++ b/pugplanner-frontend/src/game/GameCard.js
@@ -93,7 +93,9 @@ export const GameCard = ({ game }) => {
                               ? `${game.maxPlayers} / ${game.maxPlayers} with ${
                                    game.currentPlayers - game.maxPlayers
                                 } on wait-list`
-                              : `${game.currentPlayers} / ${game.maxPlayers}`
+                              : game.currentPlayers 
+                                 ? `${game.currentPlayers} / ${game.maxPlayers}`
+                                 : game.maxPlayers
                            : game.maxPlayers}
                      </dd>
                   </div>

--- a/pugplanner-frontend/src/game/GameDetails.js
+++ b/pugplanner-frontend/src/game/GameDetails.js
@@ -241,8 +241,8 @@ export const GameDetails = ({ isAdmin }) => {
                               {isRosterEmpty
                                  ? game.maxPlayers
                                  : isWaitList
-                                 ? `${game.maxPlayers} / ${game.maxPlayers} with ${waitList.length} on wait-list`
-                                 : `${game.currentPlayers} / ${game.maxPlayers}`}
+                                    ? `${game.maxPlayers} / ${game.maxPlayers} with ${waitList.length} on wait-list`
+                                    : `${game.currentPlayers} / ${game.maxPlayers}`}
                            </dd>
                         </div>
                         <div className="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">

--- a/pugplanner-frontend/src/game/GameDetails.js
+++ b/pugplanner-frontend/src/game/GameDetails.js
@@ -242,7 +242,7 @@ export const GameDetails = ({ isAdmin }) => {
                                  ? game.maxPlayers
                                  : isWaitList
                                  ? `${game.maxPlayers} / ${game.maxPlayers} with ${waitList.length} on wait-list`
-                                 : `${roster.length} / ${game.maxPlayers}`}
+                                 : `${game.currentPlayers} / ${game.maxPlayers}`}
                            </dd>
                         </div>
                         <div className="bg-gray-50 px-4 py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">


### PR DESCRIPTION
This PR resolves #23 . The game model and repository methods for getting all games and getting game by Id have been expanded to include the game's current roster count.

The front-end code has been updated to utilize the new game property where possible.

There potentially is an issue with games that have no one in their roster, but more testing is needed to be done.
EDIT: This has been fixed with [this commit](https://github.com/shanedbutler/pug-planner/pull/56/commits/ba3a3808bc74c6e4ec29c9a3ae8ef42d05941644) by refactoring the subquery to count pks from the roster table instead of the game table. 