### PR TITLE
Add player admin property to edit object body

### DIFF
--- a/pugplanner-frontend/src/profile/PlayerEdit.js
+++ b/pugplanner-frontend/src/profile/PlayerEdit.js
@@ -137,6 +137,7 @@ export const PlayerEdit = ({ userId }) => {
             emergencyName: emergencyNameRef.current.value,
             emergencyPhone: emergencyPhoneRef.current.value.replace(/\D/g, ''),
             active: player.active,
+            admin: player.admin,
          };
          editUserFetch(editedUser).then(() => navigate(`/profile/${userId}`));
       }


### PR DESCRIPTION
This PR resolves #57 . 

The property for admin was missing from the edited player object. It has been added and the bug has a been fixed.